### PR TITLE
chore: Remove NODE_AUTH_TOKEN usage

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -24,5 +24,3 @@ jobs:
 
       - name: Publish package
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Removed NODE_AUTH_TOKEN environment variable from npm publish step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build-release workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->