### PR TITLE
fix: add credential test for n8n compliance

### DIFF
--- a/credentials/HostingerApi.credentials.ts
+++ b/credentials/HostingerApi.credentials.ts
@@ -1,5 +1,6 @@
 import {
 	IAuthenticateGeneric,
+	ICredentialTestRequest,
 	ICredentialType,
 	INodeProperties,
 } from 'n8n-workflow';
@@ -23,12 +24,21 @@ export class HostingerApi implements ICredentialType {
 			description: 'Enter your Hostinger API token',
 		},
 	];
+
 	authenticate: IAuthenticateGeneric = {
 		type: 'generic',
 		properties: {
 			headers: {
 				Authorization: '=Bearer {{$credentials.apiKey}}',
 			},
+		},
+	};
+
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: this.documentationUrl,
+			url: '/api/billing/v1/subscriptions',
+			method: 'GET',
 		},
 	};
 }


### PR DESCRIPTION
added missing credential tests to comply with n8n validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added credential testing capability for Hostinger API integration, enabling users to validate their authentication credentials and connection before proceeding with API operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->