### PR TITLE
fix(deps): sync package-lock.json and document why stream-json cannot be upgraded

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,30 @@ To use this node, you will need to authenticate with the Hostinger API.
 
 No known version incompatibilities at this time.
 
+### Known dependency constraint: `stream-json`
+
+`stream-json` is pinned to `1.9.1` and **cannot currently be upgraded**. Dependabot
+flags it for [GHSA-528h-pc64-c93x](https://github.com/advisories/GHSA-528h-pc64-c93x)
+(moderate, CWE-407), but no upgrade path exists:
+
+- It is a **transitive dev dependency only**
+  (`@n8n/node-cli` -> `@n8n/backend-common` -> `stream-json`), marked `"dev": true`
+  in `package-lock.json`. This package publishes only `dist/`, so it never reaches users.
+- `@n8n/backend-common` pins `stream-json` to exactly `1.9.1`. This is still true on
+  the latest `@n8n/node-cli` (`0.47.1`), so bumping the CLI does not help.
+- The advisory range is `<=3.4.0`. The first patched release, `3.5.0`, is **ESM-only**
+  (`"type": "module"`, Node >= 22) and renamed `Assembler.js` to `src/assembler.js`
+  behind a restrictive `exports` map. Because `@n8n/backend-common` is CommonJS and
+  calls `require("stream-json/Assembler")`, an `overrides` entry pointing at `3.5.0+`
+  breaks the toolchain with `MODULE_NOT_FOUND`.
+- The vulnerable code path is **not reachable**. The advisory covers the
+  `pick`/`ignore`/`filter`/`replace` filters; the only consumer
+  (`@n8n/backend-common/dist/utils/flatted-async.js`) uses just `parser()` and
+  `Assembler`, and nothing else in the tree imports `stream-json`.
+
+Revisit once `@n8n/backend-common` relaxes its pin or ships a `stream-json 3.x`
+compatible release.
+
 ## Usage
 
 1. **Add the Hostinger API node** to your workflow.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1835,6 +1835,18 @@
         }
       }
     },
+    "node_modules/@n8n/ai-utilities/node_modules/ignore": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.8.tgz",
+      "integrity": "sha512-YYNsSlXBjMk92SKnkwvB5LOVSa6OznlFUGcsvrFgNJbJCd0M1XKeFVRc8ZByeCqz32FivYNHJVooLmdqrmvp/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/@n8n/api-types": {
       "version": "1.37.4",
       "resolved": "https://registry.npmjs.org/@n8n/api-types/-/api-types-1.37.4.tgz",


### PR DESCRIPTION
## Summary

Dependabot asked us to move `stream-json` to `3.5.0+` (GHSA-528h-pc64-c93x). **I investigated and that upgrade is not possible** — it hard-breaks the build toolchain, and no compatible patched version exists. Details and evidence below.

While verifying this, I found a **separate, unrelated problem: `npm ci` is currently broken on `main`.** Since `build-release.yaml` runs `npm ci` on every push to `main`, **releases are failing today.** That is what this PR actually fixes, plus documentation so the recurring Dependabot alert has a written answer.

## What changed

- **`package-lock.json`** — added the missing `ignore@7.0.8` transitive entry to restore `package.json` ↔ lockfile sync. 12 insertions, zero deletions; `libc` metadata that Linux CI relies on is deliberately preserved.
- **`README.md`** — new "Known dependency constraint: `stream-json`" subsection under Compatibility.

No dependency versions change, and no runtime code is touched.

## The `npm ci` breakage (pre-existing on `main`)

```
$ npm ci
npm error code EUSAGE
npm error `npm ci` can only install packages when your package.json and
npm error package-lock.json or npm-shrinkwrap.json are in sync.
npm error Missing: ignore@7.0.8 from lock file
```

Reproducible on a clean checkout of `main` with no local changes.

## Why `stream-json` cannot be upgraded

1. **Dev-only, never shipped.** The chain is `@n8n/node-cli` → `@n8n/backend-common` → `stream-json`, marked `"dev": true` throughout. This package publishes only `dist/`, so it never reaches users.
2. **No upstream fix exists.** `@n8n/backend-common` pins `stream-json` to exactly `1.9.1`. That is still true on the newest `@n8n/node-cli` (`0.47.1`), so bumping the CLI does not help. npm's own suggested "fix" is a *major downgrade* of `@n8n/node-cli` to `0.20.0`.
3. **Every patched version is API-incompatible.** The advisory range is `<=3.4.0`. The first patched release, `3.5.0`, is ESM-only (`"type": "module"`, Node >= 22) and renamed `Assembler.js` → `src/assembler.js` behind a restrictive `exports` map. `@n8n/backend-common` is CommonJS and calls `require("stream-json/Assembler")`.

I tested the `overrides` approach Dependabot suggested:

```
$ # package.json: "overrides": { "stream-json": "3.6.0" }
$ node -e "require('@n8n/backend-common')"
Error: Cannot find module '.../node_modules/stream-json/src/Assembler'
  code: 'MODULE_NOT_FOUND'
```

`flatted-async.js` is eagerly loaded when `@n8n/backend-common` is imported, so this is not a lazy edge case — it breaks `build`, `lint` and `release` outright.

4. **The vulnerable code path is unreachable.** The advisory is an O(depth²) DoS in the `pick`/`ignore`/`filter`/`replace` filters. The only consumer, `@n8n/backend-common/dist/utils/flatted-async.js`, uses just `parser()` and `Assembler` — no filters. Nothing else in the dependency tree imports `stream-json`. CVSS is 6.2 with `AV:L` (local) and availability-only impact.

## Suggested follow-up

The alert will keep reappearing. Options, for a maintainer to decide:
- Dismiss it in the GitHub UI as "vulnerable code is not actually used" (the repo has no `.github/dependabot.yml`, so I did not add in-repo config that might override org-level settings), or
- Track `@n8n/backend-common` and revisit once it relaxes the pin.

## Verification

Run against a clean `rm -rf node_modules`:

| Command | Exit |
|---|---|
| `npm ci` | 0 |
| `npm run build` | 0 |
| `npm run lint` | 0 |

`npm ci` fails on `main` and passes on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)